### PR TITLE
Scene IDs do not have to be the same as the file name

### DIFF
--- a/include/vgame/vix_scene.h
+++ b/include/vgame/vix_scene.h
@@ -58,18 +58,18 @@ namespace Vixen {
 
 		/*SETTER FUNCTIONS*/
 		void SetID(std::string id);
-		void SetName(std::string name);
+		void SetFileName(std::string name);
 
 		void SetMainCamera(ICamera3D* camera);
 
 		/*GETTER FUNCTIONS*/
 		const std::string& GetID();				//returns ID of scene
-		const std::string& GetName();
+		const std::string& GetFileName();
 
 	private:
 		uint32_t						m_order;
 		std::string						m_id;				//scene ID
-		std::string						m_name;
+		std::string						m_fileName;
 		bool							m_paused;
 		bool							m_hidden;
 		std::vector<GameObject*>		m_topLevelObjects;

--- a/include/vgame/vix_scenemanager.h
+++ b/include/vgame/vix_scenemanager.h
@@ -34,12 +34,13 @@ namespace Vixen {
     class VIX_API SceneManager : public Singleton<SceneManager>
     {
         typedef std::map<std::string, Scene*> SceneMap;
+		typedef std::map<std::string, std::string> SceneFileMap;
 		typedef std::vector<Scene*> SceneList;
     public:
        
         static bool				Initialize();
         static void				DeInitialize();
-		static bool				LoadScene(std::string fileName, std::string id = "", bool initial = false);
+		static Scene*				LoadScene(std::string fileName, bool initial = false);
         static void				OpenScene(std::string id);
 		static void             AddScene(Scene* scene);
         static void				UpdateScenes();
@@ -59,6 +60,7 @@ namespace Vixen {
 
     private:
         SceneMap   m_scenes;
+		SceneFileMap m_sceneFiles;
 		SceneList  m_sceneList;
         Scene*     m_current;
     };

--- a/source/vgame/vix_scene.cpp
+++ b/source/vgame/vix_scene.cpp
@@ -137,9 +137,9 @@ namespace Vixen {
 		m_id = id;
 	}
 
-	void Scene::SetName(std::string name)
+	void Scene::SetFileName(std::string name)
 	{
-		m_name = name;
+		m_fileName = name;
 	}
 
 	void Scene::SetMainCamera(ICamera3D * camera)
@@ -165,13 +165,9 @@ namespace Vixen {
 		return m_id;
 	}
 
-	const std::string& Scene::GetName()
+	const std::string& Scene::GetFileName()
 	{
-		if (m_name.empty()) 
-		{
-			return m_id;
-		}
-		return m_name;
+		return m_fileName;
 	}
 
 	bool Scene::IsPaused()


### PR DESCRIPTION
Fixes Bug #2, accomplishes goal of commit b225aea1b4d383f0066facf9222d6f3ec9c6cfe1.
